### PR TITLE
Enforce a Restricted Content Security Policy by Default

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -23,6 +23,7 @@
     "permissions": [
       "https://*/*"
     ],
+    "content_security_policy": "default-src 'self';",
     "content_scripts": [
       {
         "matches": [


### PR DESCRIPTION
Including a strict Content Security Policy in the manifest by default encourages developers to follow security coding practices.